### PR TITLE
Adjust colors to be a bit more accessible and add a few more colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 public/
+.hugo_build.lock

--- a/hugo-theme-console/static/hugo-theme-console/css/console.css
+++ b/hugo-theme-console/static/hugo-theme-console/css/console.css
@@ -50,14 +50,14 @@
     :root {
         --background-color: #222225;
         --page-width: 60em;
-        --font-color: #e8e9ed;
-        --invert-font-color: #222225;
-        --secondary-color: #a3abba;
-        --tertiary-color: #a3abba;
+        --font-color: #ffffff;
+        --invert-font-color: #191919;
+        --secondary-color: #b8c0d0;
+        --tertiary-color: #b8c0d0;
         --primary-color: #62c4ff;
         --error-color: #ff3c74;
         --progress-bar-background: #3f3f44;
-        --progress-bar-fill: #62c4ff;
+        --progress-bar-fill: #82d4ff;
         --code-bg-color: #3f3f44;
     }
 }
@@ -65,12 +65,13 @@
 @media (prefers-color-scheme: light) {
     :root {
         --background-color: #fff;
-        --font-color: #151515;
+        --font-color: #222222;
         --invert-font-color: #fff;
-        --primary-color: #1a95e0;
-        --secondary-color: #727578;
+        --primary-color: #0a6cb1;
+        --secondary-color: #555759;
+        --tertiary-color: #555759;
         --error-color: #d20962;
-        --progress-bar-background: #727578;
+        --progress-bar-background: #555759;
         --progress-bar-fill: #151515;
         --code-bg-color: #e8eff2;
     }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -3,22 +3,25 @@
 
 /* Atelier Dune Dark - Readable & Balanced */
 :root {
-    --background: #181815; /* Slightly darker for better contrast */
-    --foreground: #d6d3c9; /* Warmer, softer neutral for readability */
-    --primary: #9a927a; /* Softer, neutral gray-brown for headings */
-    --secondary: #c2a76d; /* Warm but not too saturated */
-    --tertiary: #7ca578; /* More distinct but still soft green */
-    --highlight: #a07c68; /* Warm, slightly desaturated brown */
-    --muted: #6f6c5f; /* Darker muted tone for subtle elements */
-    --code-bg: #24231f; /* Darker code background for contrast */
-    --info-bg: #5f7c9c; /* Slightly brighter blue-gray */
-    --info-text: #e8e4cf;
-    --warn-bg: #b79a4c; /* More golden for visibility */
-    --warn-text: #181815;
-    --error-bg: #b35b5b; /* Softer than bright red but still distinct */
-    --error-text: #e8e4cf;
-    --success-bg: #5f9566; /* Slightly stronger green */
-    --success-text: #e8e4cf;
+    --background: #181815;
+    --foreground: #e6e3d9;
+    --primary: #a59c84;
+    --secondary: #d4b97e;
+    --tertiary: #8cb989;
+    --highlight: #b18a76;
+    --muted: #8a8778;
+    --code-bg: #24231f;
+    --link-color: #7cc0ff;
+    --link-visited: #c58fff;
+    --focus-outline: #ffcc00;
+    --info-bg: #5f7c9c;
+    --info-text: #ffffff;
+    --warn-bg: #b79a4c;
+    --warn-text: #000000;
+    --error-bg: #b35b5b;
+    --error-text: #ffffff;
+    --success-bg: #5f9566;
+    --success-text: #ffffff;
 }
 
 /* Global Reset & Typography */

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -11,9 +11,6 @@
     --highlight: #b18a76;
     --muted: #8a8778;
     --code-bg: #24231f;
-    --link-color: #7cc0ff;
-    --link-visited: #c58fff;
-    --focus-outline: #ffcc00;
     --info-bg: #5f7c9c;
     --info-text: #ffffff;
     --warn-bg: #b79a4c;


### PR DESCRIPTION
- I've gone through the colors around the site and tweaked some of them to improve accessibility. The site looks very similar to before. These are just slight changes to improve accessibility, not a full redesign.
- I also added the `.hugo_build.lock` to the `.gitignore`. From what I understand, it is not necessary to commit it.

I am clearly not a designer by any means, so any feedback is welcome!