### PR TITLE
Add Discord button to Cache Valley AI Community org page

### DIFF
--- a/content/organizations/CacheValleyAICommunity/index.md
+++ b/content/organizations/CacheValleyAICommunity/index.md
@@ -16,8 +16,14 @@ We meet to **learn** and **connect** sharing what we're working on, what we're c
 We're aiming for **bi-monthly meetups**. No fixed schedule yet, we're still finding our rhythm.
 
 ## How to Join
-Sign up for event notifications so you know when the next meetup is happening:
+The fastest way in is the Discord — say hi, lurk, or jump into a thread. Prefer quieter nudges? The email list is a second path in.
 
-<a href="https://form.typeform.com/to/uaTdLFQ7" target="_blank" rel="noopener" class="btn btn-primary" style="color: #ffffff; text-decoration: none; padding: 0.875rem 2rem; font-size: 1.125rem; font-weight: 600;">Join the Email List</a>
+<div style="display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 1rem 0;">
+  <a href="https://discord.gg/uFA8GJmq" target="_blank" rel="noopener" class="btn btn-primary" style="background-color: #5865F2; border-color: #5865F2; color: #ffffff; text-decoration: none; padding: 0.875rem 2rem; font-size: 1.125rem; font-weight: 600; display: inline-flex; align-items: center; gap: 0.5rem;">
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.317 4.369A19.791 19.791 0 0 0 16.558 3a13.973 13.973 0 0 0-.622 1.276 18.273 18.273 0 0 0-5.487 0A13.227 13.227 0 0 0 9.815 3a19.736 19.736 0 0 0-3.762 1.369C2.493 9.79 1.482 15.072 1.987 20.281a19.92 19.92 0 0 0 6.063 3.06 14.62 14.62 0 0 0 1.296-2.106 12.92 12.92 0 0 1-2.039-.975c.171-.124.339-.253.5-.385a14.21 14.21 0 0 0 12.387 0c.163.132.331.261.5.385a12.97 12.97 0 0 1-2.041.975 14.535 14.535 0 0 0 1.296 2.106 19.85 19.85 0 0 0 6.066-3.06c.591-6.057-.99-11.295-4.198-15.912ZM8.5 16.32c-1.21 0-2.207-1.108-2.207-2.473s.978-2.475 2.207-2.475 2.227 1.119 2.207 2.475c0 1.365-.978 2.473-2.207 2.473Zm7.001 0c-1.21 0-2.207-1.108-2.207-2.473s.978-2.475 2.207-2.475 2.227 1.119 2.207 2.475c0 1.365-.978 2.473-2.207 2.473Z"/></svg>
+    Join the Discord
+  </a>
+  <a href="https://form.typeform.com/to/uaTdLFQ7" target="_blank" rel="noopener" class="btn btn-primary" style="color: #ffffff; text-decoration: none; padding: 0.875rem 2rem; font-size: 1.125rem; font-weight: 600;">Join the Email List</a>
+</div>
 
 No membership, no dues, no commitment. Just show up when you can.


### PR DESCRIPTION
## Summary

- Adds a **Join the Discord** button (Discord-blurple, with the Discord icon) to the Cache Valley AI Community organization page so visitors have a one-click on-ramp into the community.
- Reorders the buttons so Discord is presented as the primary on-ramp and the email list as the secondary path.
- Rewrites the short intro line above the buttons to match.

Discord URL used: `https://discord.gg/uFA8GJmq`

## Test plan
- [ ] Build the site locally with `hugo serve`
- [ ] Visit `/organizations/cachevalleyaicommunity/` and confirm both buttons render side-by-side, wrap on narrow screens, and link to the right URLs
- [ ] Confirm the Discord SVG icon shows up on both light and dark themes if applicable