### PR TITLE
Adding link unfurling to site metadata using frontmatter

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,3 +1,4 @@
+baseURL = 'https://www.cachevalley.co/'
 languageCode = 'en-us'
 title = 'Cache Valley Communities'
 theme = 'community'

--- a/themes/community/layouts/_default/baseof.html
+++ b/themes/community/layouts/_default/baseof.html
@@ -4,15 +4,22 @@
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>
-            {{ .Site.Title }}{{ $url := urls.Parse .Page.Permalink }}{{
-            $url.Path }}
+            {{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}
         </title>
-        {{ with .Site.Params.description }}
+        {{ $pageDescription := "" }}
+        {{ with .Description }}{{ $pageDescription = . }}
+        {{ else }}{{ with .Params.description }}{{ $pageDescription = . }}
+        {{ else }}{{ if .IsPage }}{{ with .Summary }}{{ $pageDescription = (. | plainify | truncate 200) }}{{ end }}
+        {{ end }}{{ end }}{{ end }}
+        {{ if not $pageDescription }}{{ with .Site.Params.description }}{{ $pageDescription = . }}{{ end }}{{ end }}
+        {{ with $pageDescription }}
         <meta name="description" content="{{ . }}" />
         {{ end }}
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="robots" content="all,follow" />
         <meta name="googlebot" content="index,follow,snippet,archive" />
+        {{ partial "opengraph.html" . }}
+        {{ partial "twitter_cards.html" . }}
         {{ $customcss := "/css/custom.css" | relURL }} {{ $vimemulated :=
         "/js/vim-emulated.js" | relURL }} {{ $commandpallete :=
         "/js/command-pallete.js" | relURL }}

--- a/themes/community/layouts/partials/opengraph.html
+++ b/themes/community/layouts/partials/opengraph.html
@@ -1,13 +1,18 @@
-<meta property="og:title" content="{{ .Title }}" />
-<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
+<meta property="og:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }}{{ end }}" />
+<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Params.description }}{{ . }}{{ else }}{{ if .IsPage }}{{ with .Summary }}{{ . | plainify | truncate 200 }}{{ end }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}{{ end }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 
 {{- with .Params.image }}
 {{ $image := $.Resources.GetMatch . }}
 {{ with $image }}
-  {{ $thumb := .Resize "400x" }}
-<meta property="og:image" content="{{ $thumb.Permalink }}">
+  {{ $thumb := .Resize "1200x webp q85" }}
+<meta property="og:image" content="{{ $thumb.Permalink }}" />
+<meta property="og:image:width" content="{{ $thumb.Width }}" />
+<meta property="og:image:height" content="{{ $thumb.Height }}" />
+<meta property="og:image:alt" content="{{ $.Title }}" />
+{{ else }}
+<meta property="og:image" content="{{ . | absURL }}" />
 {{ end }}
 {{ end }}
 

--- a/themes/community/layouts/partials/opengraph.html
+++ b/themes/community/layouts/partials/opengraph.html
@@ -6,7 +6,7 @@
 {{- with .Params.image }}
 {{ $image := $.Resources.GetMatch . }}
 {{ with $image }}
-  {{ $thumb := .Resize "1200x webp q85" }}
+  {{ $thumb := .Resize "1200x jpg q85" }}
 <meta property="og:image" content="{{ $thumb.Permalink }}" />
 <meta property="og:image:width" content="{{ $thumb.Width }}" />
 <meta property="og:image:height" content="{{ $thumb.Height }}" />

--- a/themes/community/layouts/partials/twitter_cards.html
+++ b/themes/community/layouts/partials/twitter_cards.html
@@ -1,7 +1,7 @@
 {{- with .Params.image }}
 {{ $image := $.Resources.GetMatch . }}
 {{ with $image }}
-{{ $thumb := .Resize "1200x webp q85" }}
+{{ $thumb := .Resize "1200x jpg q85" }}
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:image" content="{{ $thumb.Permalink }}" />
 <meta name="twitter:image:alt" content="{{ $.Title }}" />

--- a/themes/community/layouts/partials/twitter_cards.html
+++ b/themes/community/layouts/partials/twitter_cards.html
@@ -1,19 +1,25 @@
 {{- with .Params.image }}
 {{ $image := $.Resources.GetMatch . }}
 {{ with $image }}
-{{ $thumb := .Resize "400x" }}
-<meta name="twitter:card" content="summary_large_image"/>
-<meta name="twitter:image" content="{{ $thumb.Permalink }}">
+{{ $thumb := .Resize "1200x webp q85" }}
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:image" content="{{ $thumb.Permalink }}" />
+<meta name="twitter:image:alt" content="{{ $.Title }}" />
+{{ else }}
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:image" content="{{ . | absURL }}" />
 {{ end }}
+{{ else }}
+<meta name="twitter:card" content="summary" />
 {{ end }}
 
-<meta name="twitter:title" content="{{ .Title }}"/>
-<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>
+<meta name="twitter:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }}{{ end }}" />
+<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Params.description }}{{ . }}{{ else }}{{ if .IsPage }}{{ with .Summary }}{{ . | plainify | truncate 200 }}{{ end }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}{{ end -}}" />
 {{ with .Site.Params.Social.twitter -}}
-<meta name="twitter:site" content="@{{ . }}"/>
+<meta name="twitter:site" content="@{{ . }}" />
 {{ end -}}
 {{ range .Site.Params.Authors }}
 {{ with .twitter -}}
-<meta name="twitter:creator" content="@{{ . }}"/>
+<meta name="twitter:creator" content="@{{ . }}" />
 {{ end -}}
 {{ end -}}


### PR DESCRIPTION
I noticed that when sharing links in Discord that there was no title/description/featured image in the unfurl. This PR adds metadata tags so that links will inherit the metadata given by the frontmatter on posts.

Verified with `ngrok`:

<img width="835" height="598" alt="image" src="https://github.com/user-attachments/assets/5886e5ac-c34d-4ef2-addc-5784c9dd8ca7" />